### PR TITLE
Update specification for LSP usecase

### DIFF
--- a/specification/request-specification.md
+++ b/specification/request-specification.md
@@ -16,11 +16,11 @@ WebView Endpoint
 {% api-method-spec %}
 {% api-method-request %}
 {% api-method-path-parameters %}
-{% api-method-parameter type="string" name="requestorId" required=true %}
+{% api-method-parameter type="string" name="fi" required=true %}
 Unique requestor identifier. This will be encrypted using Base64/XOR along with **reqdate** field.
 {% endapi-method-parameter %}
 
-{% api-method-parameter type="ENUM" name="requestorType" required=true %}
+{% api-method-parameter type="ENUM" name="requestorType" required=false %}
 Type of the requestor. This field will hold the values - FIU & LSP. The ENUM field would be expanded to accommodate new participants for any future requirements.  This will be encrypted using Base64/XOR along with **reqdate** field.
 {% endapi-method-parameter %}
 

--- a/specification/request-specification.md
+++ b/specification/request-specification.md
@@ -54,10 +54,10 @@ Below are the parameters that will be encrypted using AES256 encryption algorith
 
 | **Parameter name** | **Parameter type** | **Parameter description** |
 | :--- | :--- | :--- |
-| txnid | String | UUID txnid. Uniquely identifies a particular redirection event. This same value will be returned by AA to FIU in the ecres txnid field. |
-| sessionid | String | Value that represents a ‘state’ \(or session\) on the FIU end. This value is opaque to AA and will be returned as is to the FIU by AA in ecres sessionid field. |
+| txnid | String | UUID txnid. Uniquely identifies a particular redirection event. This same value will be returned by AA to requestor in the ecres txnid field. |
+| sessionid | String | Value that represents a ‘state’ \(or session\) on the requestor end. This value is opaque to AA and will be returned as is to the requestor by AA in ecres sessionid field. |
 | userid | String | The AA user id \( Refer to A\] below \) |
-| redirect | String | FIU Url that AA needs to call back after the user has provided consent in the AA domain. The value of this parameter should be URL encoded if the value contains url parameters. This is required in order to remove ambiguity between the parameters of ecreq \(separated by ‘&’ character\) with the parameters in the redirect url. |
+| redirect | String | Requestor Url that AA needs to call back after the user has provided consent in the AA domain. The value of this parameter should be URL encoded if the value contains url parameters. This is required in order to remove ambiguity between the parameters of ecreq \(separated by ‘&’ character\) with the parameters in the redirect url. |
 | srcref | Array | Array of consent handle id(s), as returned by AA server to the /Consent request api invoked by the FIU(s) on the AA prior to this redirection call.|
 
 ## userid

--- a/specification/response-specification.md
+++ b/specification/response-specification.md
@@ -26,7 +26,7 @@ Encrypted parameters \(see below\)
 format will be ddmmyyyyhh24misss UTC
 {% endapi-method-parameter %}
 
-{% api-method-parameter name="requestorId" type="string" required=true %}
+{% api-method-parameter name="fi" type="string" required=true %}
 Unique AA identifier. This will be encrypted using Base64/XOR along with resdate field
 {% endapi-method-parameter %}
 {% endapi-method-path-parameters %}

--- a/specification/response-specification.md
+++ b/specification/response-specification.md
@@ -55,16 +55,9 @@ Below are the parameters that will be encrypted using AES256 encryption algorith
 | txnid | String | UUID txnid \( To be sent back from the request \) |
 | sessionid | String | Value of sessionid received in the ‘ecreq’ field in the request. |
 | userid | String | The AA user id |
-| srcref | Array consentHandleDetails | Consent handle details for the array of consents received in the ecreq ‘srcref’ field |
-
-## consentHandleDetails
-
-| **Parameter name** | **Parameter type** | **Parameter description** |
-| :--- | :--- | :--- |
-| consentHandle | String | Consent Handle ID |
 | status | String | The status ‘S’ for success and ‘F’ for failure |
 | errorcode | String | The response code : 0 if status is ‘S’ and others for failure (Refer to Error Codes table below) |
-
+| srcref | Array | Array of accepted consent handle identifiers |
 
 ## Error codes
 

--- a/specification/response-specification.md
+++ b/specification/response-specification.md
@@ -55,7 +55,7 @@ Below are the parameters that will be encrypted using AES256 encryption algorith
 | txnid | String | UUID txnid \( To be sent back from the request \) |
 | sessionid | String | Value of sessionid received in the ‘ecreq’ field in the request. |
 | userid | String | The AA user id |
-| status | String | The status ‘S’ for success and ‘F’ for failure |
+| status | String | The status ‘S’ for success ( atleast one consent is approved ) and ‘F’ for failure ( all consents declined ) |
 | errorcode | String | The response code : 0 if status is ‘S’ and others for failure (Refer to Error Codes table below) |
 | srcref | Array | Array of accepted consent handle identifiers |
 

--- a/specification/response-specification.md
+++ b/specification/response-specification.md
@@ -57,7 +57,7 @@ Below are the parameters that will be encrypted using AES256 encryption algorith
 | userid | String | The AA user id |
 | status | String | The status ‘S’ for success ( atleast one consent is approved ) and ‘F’ for failure ( all consents declined ) |
 | errorcode | String | The response code : 0 if status is ‘S’ and others for failure (Refer to Error Codes table below) |
-| srcref | Array | Array of accepted consent handle identifiers |
+| srcref | Array | Array of accepted consent handle identifiers only in case of LSP |
 
 ## Error codes
 


### PR DESCRIPTION
The specs have been updated to include redirection from a non-FIU participant i.e. an LSP. The current AA specs handle only single FIU use cases. In case of an LSP, a loan application is sent to multiple FIUs and hence, multiple consents are created for the same user. To accommodate this change and enable LSPs to show multiple consents, an array of consent handles need to be managed by the AA.